### PR TITLE
Better README files, docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,107 @@
-# UA (ENG - below)
+<h1 align="center">Russian warship, go fuck yourself!</h1>
+<p align="center">
+   <a href="./README.md">Українське README</a> |
+   <a href="./README_EN.md">English README</a>
+</p>
 
-# Запустіть цю програму з Python 3.8 або новішої версії.\
+## 🤔 Що це?
 
-<b>Ця програма використовує російські проксі та залучає сайти для атаки через наш API, який сканує нікчемні веб-сайти.
-\
-Ця програма використовує проксі, але будьте обережні, а також захистіть свій МАШИН за допомогою VPN
-</b>
+- В репі лежить [Python 3](https://python.org) [скрипт](./attack.py), який використовує російські проксі та залучає сайти для атаки через наш API, який сканує нікчемні веб-сайти.
+- ⚠ Скрипт використовує проксі, але будьте обережні, бажано захистити себе за допомогою VPN.
 
-Отримайте PYTHON З python.org
-<br>
-<b>Інструкції зі встановлення Python (windows) https://python-scripts.com/install-python-windows</b>
-<br>
-<i>Будьте обережні, що в Linux ви також можете мати версію 2 на python, і це означає, що вам потрібно запустити цю програму за допомогою команди python3 і встановити вимоги до встановлення за допомогою команди pip3</i>
-<br>
-<br>
+## 🚀 Швидкий старт
 
-# Для людей які мають встановлений docker або docker desktop
+### Windows 
 
-Встановити докєр можна так - https://ravesli.com/ustanovka-docker-v-windows/
+- Ставимо [Python 3.8](https://python.org) або новіший ([інструкція](https://python-scripts.com/install-python-windows))
+  > ⚠ Обов'язково ставимо галочку навпроти `Add Python to PATH` ([скрін](http://wind10.ru/wp-content/uploads/2020/02/pp_image_4620_v0cz5agbht0001_add_Python_to_Path.png))
 
-1. sudo docker pull lvinni/russian-warship-go-fuckyourself
-2. sudo docker run lvinni/russian-warship-go-fuckyourself
-   <br>
-   <br>
+- Зтягуэмо репу:
+  ```shell
+  git clone https://github.com/Luzhnuy/attacker.git
+  ```
 
-## Для людей, не дуже обізнаних в інформатиці, користувачів Windows 7-11
+- Запускаємо `install.bat` шоб встановити всі необхідні депенденсі
+
+- Через термінал (командну строку чи PowerShell) запускаємо скрипт:
+  ```shell
+  python attack.py
+  ```
+
+### Linux та MacOS
+
+- Ставимо [Python 3.8](https://python.org) або новіший
+  > ⚠ В Linux ваша система може мати попередньо встановлений Python версії 2, і це означає, що вам потрібно запустити цю програму за допомогою команди `python3` і встановити вимоги до встановлення за допомогою команди `pip3`
+
+- Зтягуэмо репу:
+  ```shell
+  git clone https://github.com/Luzhnuy/attacker.git
+  ```
+
+- Встановлюємо всі необхідні депенденсі:
+  ```shell
+  pip install -r requirements.txt
+  ```
+
+- Запускаємо скрипт:
+  ```shell
+  python attack.py
+  ```
+
+### Docker
+- Ставимо [Docker](https://docker.com): 
+  - Docker for Windows: https://ravesli.com/ustanovka-docker-v-windows/
+  - Docker for MacOS: https://docs.docker.com/desktop/mac/install/
+  - Linux: https://docs.docker.com/engine/install/
+
+- Зтягуємо докер імейдж:
+
+  ```shell
+  docker pull lvinni/russian-warship-go-fuckyourself
+  ```
+
+- Запускаємо контейнер:
+
+  ```shell
+  docker run --rm lvinni/russian-warship-go-fuckyourself
+  ```
+
+### Docker Compose
+
+`docker-compose` дозволяє легко запускати контейнери параллельно без необхідності тримати відкритими декілька терминалів. Для запуску на серверах - саме те що треба.
+
+- Зтягуэмо репу:
+
+  ```shell
+  git clone https://github.com/Luzhnuy/attacker.git
+  ```
+
+- Збираємо та запускаємо **параллельно** `5` контейнерів (по `500` коннектів на кожному):
+
+  ```shell
+  docker-compose up --build --scale attacker=5
+  ```
+
+- Зупинити всі контейнери з компоуз файлу: `Ctrl + C`
+
+---
+
+### Для людей, не дуже обізнаних в інформатиці, користувачів Windows
 
 1. Скачайте архів https://drive.google.com/file/d/1aQR53fcbvkGY-bY0V4YhzLY6obh8H6Ln/view?usp=sharing
-2. Розрархівуйте кудись. ВАЖЛИВО! НЕ на робочий стіл, та не в папку з іменем кирилицею, краще всього в корінь диску D скажімо.
-3. Знайдіть файл install.bat (можливо він буде у вас відображатися як просто install). Відмітьте його та натиснувши праву кнопку мишки на ньому, виберіть з меню "Запустить от Администратора".
+
+2. Розрархівуйте кудись.
+   > ⚠ ВАЖЛИВО! НЕ на робочий стіл, та не в папку з іменем кирилицею, краще всього в корінь диску `D:` скажімо.
+
+3. Знайдіть файл `install.bat` (можливо він буде у вас відображатися як просто install).
+   
+   Відмітьте його та натиснувши праву кнопку мишки на ньому, виберіть з меню `Запустить от Администратора`.
+
 4. Виконайте по порядку крок за кроком все, що побачите в чорному вікні (натисніть цифру відповідного пункту, нажміть Ентер, дозвольте програмам встановитися, по закінченню выберіть слідуючий пункт.
    <i>Наприклад "Встановити python (step1)" - Вам потрібно ввести цифру 1 і натиснути enter</i>
+
 5. Коли процесс встановлення всього потрібного буде закінчено, відкриється провідник, в якому ви можете запустити файл Attack.bat (можливо буде просто Attack).
 
 В майбутньому, не потрібно більше запускати install, для початку роботи достатньо запускати хіба Attack.bat. Також не треба провіряти обновлення, цей процес відбувається автоматично.
 
-## Якщо ви вже встановили bash на своїй машині з Windows - не використовуйте bash, використовуйте powershell або cmd
-
-ДЛЯ ЗАПУСК ЦЬОГО ДОДАТКУ:
-
-1. pip install -r requirements.txt
-2. python attack.py
-3. Ви можете запускати багато процесів цієї програми в різних вікнах, але максимальний розмір процесів для 8 CPU становить 4
-
-# ENG
-
-# RUN this app with Python 3.8 or higher.\
-
-<b>This app using russian proxies and get sites to attack from our API which scanning bastards websites.
-\
-This app using proxies but be careful and also protect your MACHINE with VPN
-</b>
-
-GET PYTHON FROM python.org
-<br>
-<b>Python installation instructions (windows) https://python-scripts.com/install-python-windows</b>
-<br>
-<i>Be carefull that on linux you can also have version 2 on python and this mean that you need to run this app with python3 command and install requirements with pip3 command</i>
-<br>
-<br>
-
-## If you have already installed bash on your windows machine - don't use bash, use powershell or cmd
-
-FOR RUNNING THIS APP:
-
-1. pip install -r requirements.txt
-2. python attack.py
-3. You can run many process of this app in different window, but the max size of processes for 8CPU is 4
-
-<br>
-<br>
-# For people who have a docker or desktop docker installed
-You can install a docker like this - https://ravesli.com/ustanovka-docker-v-windows/
-
-1. sudo docker pull lvinni / russian-warship-go-fuckyourself
-2. sudo docker run lvinni / russian-warship-go-fuckyourself
-
-## For people who are not very familiar with computer science, users of Windows 7-11
-
-1. Download the archive https://drive.google.com/file/d/1aQR53fcbvkGY-bY0V4YhzLY6obh8H6Ln/view?usp=sharing
-2. Unpack somewhere. IMPORTANT! NOT on the desktop, and not in a folder named Cyrillic, the best way to unpack is in the root of disk D.
-3. Locate the install.bat file (you may see it as easy to install). Right-click on the file, select from the menu "Run as Administrator".
-4. Follow step by step everything you see in the black window (press the number of the corresponding item, press Enter, allow the program to install, then select the next item.
-   <i> For example "Install python (step1)" - You need to enter the number 1 and press enter </i>
-5. When the process of installing everything you need is complete, an explorer will open in which you can run the Attack.bat file (it may just be Attack).
-
-You no longer need to run the installation, just start Attack.bat to get started. You also don't need to check for updates, this process happens automatically.
-
-## If you've already installed bash on your Windows machine - don't use bash, use powershell or cmd
-
-TO LAUNCH THIS APP:
-
-1. pip install -r requirements.txt
-2. python attack.py
-3. You can run many processes of these programs in different windows, but the maximum process size for 8 CPUs is 4
+> ⚠ Якщо ви вже встановили `bash` на своїй машині з Windows - не використовуйте `bash`, використовуйте `PowerShell` або `cmd`

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,108 @@
+<h1 align="center">Russian warship, go fuck yourself!</h1>
+<p align="center">
+   <a href="./README.md">Українське README</a> |
+   <a href="./README_EN.md">English README</a>
+</p>
+
+## 🤔 Overview
+
+- The repo contains [Python 3](https://python.org) [script](./attack.py), which uses russian proxies and retrieves list of sites to attack from our API which scanning bastards websites.
+- ⚠ The script uses a proxy, but be careful, it is desirable to protect yourself with a VPN.
+
+## 🚀 Quick start
+
+### Windows
+
+- Install [Python 3.8](https://python.org) (or later version)
+  > ⚠ **IMPORTANT**: Make sure to select `Add Python to PATH` checkbox ([see screenshot](http://wind10.ru/wp-content/uploads/2020/02/pp_image_4620_v0cz5agbht0001_add_Python_to_Path.png))
+
+- Clone repository:
+  ```shell
+  git clone https://github.com/Luzhnuy/attacker.git
+  ```
+
+- Run `install.bat` to install all the required dependencies
+
+- Using terminal (command line or PowerShell) run the script:
+
+  ```shell
+  python attack.py
+  ```
+
+### Linux and MacOS
+
+- Install [Python 3.8](https://python.org) (or later version)
+  > ⚠ Linux users, your system may have Python version 2 pre-installed, which means that you need to run this program with the `python3` command and set the installation requirements with the `pip3` command.
+
+- Clone repository:
+  ```shell
+  git clone https://github.com/Luzhnuy/attacker.git
+  ```
+
+- Install all the required dependencies:
+  ```shell
+  pip install -r requirements.txt
+  ```
+
+- Run the script:
+  ```shell
+  python attack.py
+  ```
+
+### Docker
+
+- Install [Docker](https://docker.com):
+  - Docker for Windows: https://ravesli.com/ustanovka-docker-v-windows/
+  - Docker for MacOS: https://docs.docker.com/desktop/mac/install/
+  - Linux: https://docs.docker.com/engine/install/
+
+- Download docker image:
+
+  ```shell
+  docker pull lvinni/russian-warship-go-fuckyourself
+  ```
+
+- Launch the container:
+
+  ```shell
+  docker run --rm lvinni/russian-warship-go-fuckyourself
+  ```
+
+### Docker Compose
+
+`docker-compose` allows you to easily run containers in parallel without having to keep multiple terminals opened. To run on servers - perfect choice.
+
+- Clone repository:
+  ```shell
+  git clone https://github.com/Luzhnuy/attacker.git
+  ```
+
+- Build and run `5` containers **in parallel** (each handles `500` connections):
+
+  ```shell
+  docker-compose up --build --scale attacker=5
+  ```
+
+- Stop containers from `docker-compose.yml` file: `Ctrl + C`
+
+---
+
+### For people who are not very familiar with computer science, Windows users
+
+1. Download the archive https://drive.google.com/file/d/1aQR53fcbvkGY-bY0V4YhzLY6obh8H6Ln/view?usp=sharing
+
+2. Extract archive
+   > ⚠ **IMPORTANT**! DO NOT extract files to desktop folder and not to a folder contains cyrillic symbols. Preferred place to extract is the root of the drive `D:`
+
+3. Find the `install.bat` file (you may see it as just `install`).
+   
+   Click on it using right-click, select `Start as Administrator`.
+
+4. Follow step by step everything you see in the black window (press the number of the corresponding item, press Enter, allow programs to be installed, at the end select the next item.
+   <i> For example "Install python (step1)" - You need to enter the number 1 and press enter </i>
+
+5. When the process of installing everything you need is complete, a wizard will open in which you can run the Attack.bat file (maybe just Attack).
+
+In the future, you no longer need to run install, just start `attack.bat` to get started. You also don't need to check for updates, this process happens automatically.
+
+> ⚠ If you have already installed `bash` on your Windows machine - do not use` bash`, use `PowerShell` or` cmd`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  # To run several containers in parallel use scale argument:
+  # docker-compose up --build --scale attacker=5
+  attacker:
+    build: .
+    restart: always


### PR DESCRIPTION
See updated rendered README markups in my fork: https://github.com/alexander-danilenko/attacker/tree/feature/readme

---

`docker-compose` may be used for easier building and running several containers in parallel. Example of running 5 containers simultaneously: 
```
docker-compose up --build --scale attacker=5
```

That's handy for servers and does not require the opening of several terminals.