### PR TITLE
Use ENTRYPOINT in Dockerfile for being able to pass additional parameters to script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 COPY . .
-CMD [ "python", "attack.py"]
+ENTRYPOINT [ "python", "attack.py"]


### PR DESCRIPTION
See ENTRYPOINT docs: https://docs.docker.com/engine/reference/builder/#entrypoint 

Using `ENTRYPOINT` instead of `CMD` in Dockerfile it's possible to pass all the original script arguments to the container like following:

Build and tag built container:
```bash
docker build . -t attacker
``` 

Run container with 1000 threads as a parameter:
```bash
docker run --rm attacker 1000
```

Also works with the rest of the arguments, like `docker run --rm attacker --help`

So, once it will be deployed to docker hub, users could pass arguments like the following: 
```bash
docker run --rm lvinni/russian-warship-go-fuckyourself 1000
```